### PR TITLE
fix: loosen the footnotes regex

### DIFF
--- a/src/passage-suggest.ts
+++ b/src/passage-suggest.ts
@@ -272,7 +272,7 @@ export default class PassageSuggest extends EditorSuggest<PassageSuggestion> {
 
 	/** Removes footnote refs from the given text. */
 	private removeFootnoteRefs(text: string): string {
-		return text.replace(/ \[\^\w{1,9}\]/g, '');
+		return text.replace(/\[\^[^\]]*\]/g, '');
 	}
 
 	/** Removes the beginning-of-file content from the given text. */

--- a/src/passage-suggest.ts
+++ b/src/passage-suggest.ts
@@ -272,7 +272,7 @@ export default class PassageSuggest extends EditorSuggest<PassageSuggestion> {
 
 	/** Removes footnote refs from the given text. */
 	private removeFootnoteRefs(text: string): string {
-		return text.replace(/\[\^[^\]]*\]/g, '');
+		return text.replace(/[ \t]?\[\^[^\]\r\n]*\](?!:)/g, '');
 	}
 
 	/** Removes the beginning-of-file content from the given text. */


### PR DESCRIPTION
I realized part of the fix for #24 was that the regex was too tight. Loosing the regex to include no space before the `[^` fixes my issue. Also, not sure why it's limiting from 1-9 character, but I changed that too. So now it will match anything `[^ ... ]`